### PR TITLE
Backport: new pgn reader

### DIFF
--- a/external/chess.hpp
+++ b/external/chess.hpp
@@ -25,7 +25,7 @@ Source: https://github.com/Disservin/chess-library
 */
 
 /*
-VERSION: 0.4.1
+VERSION: 0.4.3
 */
 
 #ifndef CHESS_HPP
@@ -3399,6 +3399,13 @@ class Visitor {
    public:
     virtual ~Visitor(){};
 
+    /// @brief When true, the current PGN will be skipped and only
+    /// endPgn will be called, this will also reset the skip flag to false.
+    /// Has to be called after startPgn.
+    /// @param skip
+    void skipPgn(bool skip) { skip_ = skip; }
+    bool skip() { return skip_; }
+
     /// @brief Called when a new PGN starts
     virtual void startPgn() = 0;
 
@@ -3417,6 +3424,9 @@ class Visitor {
 
     /// @brief Called when a game ends
     virtual void endPgn() = 0;
+
+   private:
+    bool skip_ = false;
 };
 
 class StreamParser {
@@ -3489,6 +3499,7 @@ class StreamParser {
             // or an error happened, we need to manually call endPgn.
             if (state != State::BREAK) {
                 visitor->endPgn();
+                visitor->skipPgn(false);
             }
         }
     }
@@ -3513,6 +3524,7 @@ class StreamParser {
             if (line_start && c == '[') {
                 if (pgn_end) {
                     pgn_end = false;
+                    visitor->skipPgn(false);
                     visitor->startPgn();
                 }
 
@@ -3539,7 +3551,7 @@ class StreamParser {
 
                 line_start = false;
 
-                visitor->startMoves();
+                if (!visitor->skip()) visitor->startMoves();
                 continue;
             }
 
@@ -3550,6 +3562,7 @@ class StreamParser {
                 pgn_end = true;
 
                 visitor->endPgn();
+                visitor->skipPgn(false);
 
                 return State::BREAK;
             }
@@ -3579,7 +3592,7 @@ class StreamParser {
                     reading_value = false;
                     in_header     = false;
 
-                    visitor->header(header.first, header.second);
+                    if (!visitor->skip()) visitor->header(header.first, header.second);
 
                     header.first.clear();
                     header.second.clear();
@@ -3601,7 +3614,7 @@ class StreamParser {
                     reading_comment = false;
 
                     if (!move.empty()) {
-                        visitor->move(move, comment);
+                        if (!visitor->skip()) visitor->move(move, comment);
                         move.clear();
                         comment.clear();
                     }
@@ -3614,7 +3627,7 @@ class StreamParser {
                     }
 
                     if (!move.empty()) {
-                        visitor->move(move, comment);
+                        if (!visitor->skip()) visitor->move(move, comment);
                         move.clear();
                         comment.clear();
                     }

--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -52,30 +52,6 @@ class Analyze : public pgn::Visitor {
 
     void startPgn() override {}
 
-    void startMoves() override {
-        do_filter = !regex_engine.empty();
-
-        if (do_filter) {
-            if (white.empty() || black.empty()) {
-                return;
-            }
-
-            std::regex regex(regex_engine);
-
-            if (std::regex_match(white, regex)) {
-                filter_side = Color::WHITE;
-            }
-
-            if (std::regex_match(black, regex)) {
-                if (filter_side == Color::NONE) {
-                    filter_side = Color::BLACK;
-                } else {
-                    do_filter = false;
-                }
-            }
-        }
-    }
-
     void header(std::string_view key, std::string_view value) override {
         if (key == "FEN") {
             std::regex p("0 1$");
@@ -93,27 +69,7 @@ class Analyze : public pgn::Visitor {
         }
 
         if (key == "Result") {
-            hasResult  = true;
-            goodResult = true;
-
-            if (value == "1-0") {
-                resultkey.white = Result::WIN;
-                resultkey.black = Result::LOSS;
-            } else if (value == "0-1") {
-                resultkey.white = Result::LOSS;
-                resultkey.black = Result::WIN;
-            } else if (value == "1/2-1/2") {
-                resultkey.white = Result::DRAW;
-                resultkey.black = Result::DRAW;
-            } else {
-                goodResult = false;
-            }
-        }
-
-        if (key == "Termination") {
-            if (value == "time forfeit" || value == "abandoned") {
-                goodTermination = false;
-            }
+            hasResult = true;
         }
 
         if (key == "White") {
@@ -123,18 +79,45 @@ class Analyze : public pgn::Visitor {
         if (key == "Black") {
             black = value;
         }
-
-        skip = !(hasResult && goodTermination && goodResult);
-        skip = !hasResult; /* TODO */
     }
 
-    void move(std::string_view move, std::string_view comment) override {
-        if (skip) {
+    void startMoves() override {
+        if (!hasResult) {
+            this->skipPgn(true);
             return;
         }
 
-        if (retained_plies >= max_plies)
+        do_filter = !regex_engine.empty();
+
+        if (do_filter) {
+            if (white.empty() || black.empty()) {
+                this->skipPgn(true);
+                return;
+            }
+
+            std::regex regex(regex_engine);
+
+            if (std::regex_match(white, regex)) {
+                filter_side = Color::WHITE;
+            }
+
+            if (std::regex_match(black, regex)) {
+                if (filter_side == Color::NONE) {
+                filter_side = Color::BLACK;
+                } else {
+                do_filter = false;
+                }
+            }
+        }
+    }
+
+
+
+    void move(std::string_view move, std::string_view comment) override {
+        if (retained_plies >= max_plies) {
+            this->skipPgn(true);
             return;
+        }
 
         Move m;
 
@@ -149,7 +132,7 @@ class Analyze : public pgn::Visitor {
                                      [&](map_t::value_type& p) { ++p.second; },
                                      [&](const map_t::constructor& ctor) { ctor(std::move(fen), 1); });
             if (stop_early && is_new_entry) {
-                skip = true;
+                this->skipPgn(true);
                 return;
             }
             retained_plies++;
@@ -160,9 +143,7 @@ class Analyze : public pgn::Visitor {
         board.set960(false);
         board.setFen(STARTPOS);
 
-        goodTermination = true;
         hasResult       = false;
-        goodResult      = false;
 
         retained_plies  = 0;
 
@@ -183,17 +164,13 @@ class Analyze : public pgn::Visitor {
 
     bool skip = false;
 
-    bool goodTermination = true;
     bool hasResult       = false;
-    bool goodResult      = false;
 
     bool do_filter    = false;
     Color filter_side = Color::NONE;
 
     std::string white;
     std::string black;
-
-    ResultKey resultkey;
 
     int retained_plies = 0;
 };

--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -397,7 +397,6 @@ void process(const std::vector<std::string> &files_pgn,
 /// @param json_filename
 void save(const std::string &filename,
           const unsigned int min_count) {
-
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   std::uint64_t total = 0;
@@ -405,7 +404,7 @@ void save(const std::string &filename,
   std::ofstream out_file(filename);
   for (const auto &pair : pos_map) {
     if (pair.second >= min_count) {
-      out_file << pair.first << " ; c0 " << pair.second << std::endl;
+      out_file << pair.first << " ; c0 " << pair.second << "\n";
       total++;
     }
   }


### PR DESCRIPTION
- backports the new pgn read

Comparison:
```
patch:

Looking (recursively) for pgn files in ..\WLD_model\pgns\
Found 11700 .pgn(.gz) files, creating 128 chunks for processing.
Progress: 128/128
Time taken for processing: 10.583s
Wrote 27779199 scored positions to popular.epd for analysis in 14.562s

master:

❯ .\fastpopular.exe -r --dir ..\WLD_model\pgns\
Looking (recursively) for pgn files in ..\WLD_model\pgns\
Found 11700 .pgn(.gz) files, creating 128 chunks for processing.
Progress: 128/128
Time taken for processing: 18.669s
Wrote 27779199 scored positions to popular.epd for analysis in 163.578s

```

I noticed that master takes a really long time to write the `popular.epd` file to the disk.
Thus I replaced `std::endl` with `\n` and it's much faster ;)

```
master with "\n" instead of std::endl

❯ .\fastpopular.exe -r --dir ..\WLD_model\pgns\
Looking (recursively) for pgn files in ..\WLD_model\pgns\
Found 11700 .pgn(.gz) files, creating 128 chunks for processing.
Progress: 128/128
Time taken for processing: 18.698s
Wrote 27779199 scored positions to popular.epd for analysis in 12.336
```

After sort(ing) the patch and master file and then running a `diff` I saw no difference.