### PR TITLE
remove Results structs

### DIFF
--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -90,10 +90,6 @@ public:
       board.set960(true);
     }
 
-    if (key == "Result") {
-      hasResult = true;
-    }
-
     if (key == "White") {
       white = value;
     }
@@ -111,11 +107,6 @@ public:
   }
 
   void startMoves() override {
-    if (!hasResult) {
-      this->skipPgn(true);
-      return;
-    }
-
     if (whiteElo < min_Elo || blackElo < min_Elo) {
       this->skipPgn(true);
       return;
@@ -217,8 +208,6 @@ public:
     board.set960(false);
     board.setFen(constants::STARTPOS);
 
-    hasResult = false;
-
     retained_plies = 0;
     new_entry_count = 0;
 
@@ -248,8 +237,6 @@ private:
   Movelist moves;
 
   bool skip = false;
-
-  bool hasResult = false;
 
   bool do_filter = false;
   Color filter_side = Color::NONE;

--- a/fastpopular.hpp
+++ b/fastpopular.hpp
@@ -10,13 +10,6 @@
 
 #include "external/json.hpp"
 
-enum class Result { WIN = 'W', DRAW = 'D', LOSS = 'L' };
-
-struct ResultKey {
-  Result white;
-  Result black;
-};
-
 struct TestMetaData {
   std::optional<std::string> book;
   std::optional<bool> sprt;


### PR DESCRIPTION
Small clean up. Change allows stats/positions also to be read from games that are missing a Result key for some reason.