### PR TITLE
switch from zobrist keys to fen keys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,8 +34,8 @@ Options:
   --maxPlies <N>        Maximum number of plies to consider from the game, excluding book moves (default 20)
   --stopEarly           Stop analysing the game as soon as countStopEarly new positions are reached (default false) for the analysing thread.
   --countStopEarly <N>  Number of new positions encountered before stopping with stopEarly (default 1)
-  --minCount <N>        Minimum count of the positin before being written to file (default 1)
-  --saveCount           Add to the output file the count of each position. This adds significant memory overhead (but can be faster).
+  --minCount <N>        Minimum count of the position before being written to file (default 1)
+  --saveCount           Add to the output file the count of each position. (Only works with --omitMoveCounter).
   --omitMoveCounter     Omit movecounter when storing the FEN (the same position with different movecounters is still only stored once)
   --TBlimit <N>         Omit positions with N pieces, or fewer (default: 1)
   --omitMates           Omit positions without a legal move (check/stale mates)

--- a/external/chess.hpp
+++ b/external/chess.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.56
+VERSION: 0.6.63
 */
 
 #ifndef CHESS_HPP
@@ -33,6 +33,7 @@ VERSION: 0.6.56
 
 
 #include <functional>
+#include <utility>
 
 
 #include <cstdint>
@@ -258,7 +259,7 @@ class Rank {
 class Square {
    public:
     // clang-format off
-    enum class underlying : uint8_t {
+    enum class underlying {
         SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
         SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,
         SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3,
@@ -876,8 +877,6 @@ constexpr auto MAX_MOVES             = 256;
 
 namespace chess {
 
-constexpr static std::string_view pieces = "PNBRQKpnbrqk ";
-
 class PieceType {
    public:
     enum class underlying : std::uint8_t {
@@ -1009,17 +1008,7 @@ class Piece {
         : piece(color == Color::NONE      ? Piece::NONE
                 : type == PieceType::NONE ? Piece::NONE
                                           : static_cast<underlying>(static_cast<int>(color.internal()) * 6 + type)) {}
-    constexpr Piece(std::string_view p) : piece(underlying::NONE) {
-        for (std::size_t i = 0; i < pieces.size(); i++) {
-            if (p[0] == pieces[i]) {
-                piece = static_cast<underlying>(i);
-                return;
-            }
-        }
-
-        piece = NONE;
-        return;
-    }
+    constexpr Piece(std::string_view p) : piece(underlying::NONE) { piece = convertCharToUnderlying(p[0]); }
 
     constexpr bool operator<(const Piece& rhs) const noexcept { return piece < rhs.piece; }
     constexpr bool operator>(const Piece& rhs) const noexcept { return piece > rhs.piece; }
@@ -1068,7 +1057,9 @@ class Piece {
 
     [[nodiscard]] constexpr PieceType type() const noexcept {
         if (piece == NONE) return PieceType::NONE;
-        return static_cast<PieceType::underlying>(int(piece) % 6);
+        // return static_cast<PieceType::underlying>(int(piece) % 6);
+        return static_cast<PieceType::underlying>(static_cast<int>(piece) > 5 ? static_cast<int>(piece) - 6
+                                                                              : static_cast<int>(piece));
     }
 
     [[nodiscard]] constexpr Color color() const noexcept {
@@ -1094,6 +1085,37 @@ class Piece {
 
    private:
     underlying piece;
+
+    [[nodiscard]] constexpr static underlying convertCharToUnderlying(char c) {
+        switch (c) {
+            case 'P':
+                return WHITEPAWN;
+            case 'N':
+                return WHITEKNIGHT;
+            case 'B':
+                return WHITEBISHOP;
+            case 'R':
+                return WHITEROOK;
+            case 'Q':
+                return WHITEQUEEN;
+            case 'K':
+                return WHITEKING;
+            case 'p':
+                return BLACKPAWN;
+            case 'n':
+                return BLACKKNIGHT;
+            case 'b':
+                return BLACKBISHOP;
+            case 'r':
+                return BLACKROOK;
+            case 'q':
+                return BLACKQUEEN;
+            case 'k':
+                return BLACKKING;
+            default:
+                return NONE;
+        }
+    }
 };
 }  // namespace chess
 
@@ -1661,6 +1683,10 @@ enum class GameResultReason {
     NONE
 };
 
+// A compact representation of the board in 24 bytes,
+// does not include the half-move clock or full move number.
+using PackedBoard = std::array<std::uint8_t, 24>;
+
 class Board {
     using U64 = std::uint64_t;
 
@@ -1738,10 +1764,12 @@ class Board {
     };
 
    public:
-    explicit Board(std::string_view fen = constants::STARTPOS) {
+    explicit Board(std::string_view fen = constants::STARTPOS, bool chess960 = false) {
         prev_states_.reserve(256);
+        chess960_ = chess960;
         setFenInternal(fen);
     }
+
     virtual void setFen(std::string_view fen) { setFenInternal(fen); }
 
     static Board fromFen(std::string_view fen) { return Board(fen); }
@@ -1942,11 +1970,9 @@ class Board {
 
                         int double_check = 0;
 
-                        Bitboard occ_us    = us(stm_);
-                        Bitboard occ_opp   = us(~stm_);
-                        Bitboard occ_all   = occ_us | occ_opp;
-                        Bitboard opp_empty = ~occ_us;
-                        auto king_sq       = kingSq(stm_);
+                        Bitboard occ_us  = us(stm_);
+                        Bitboard occ_opp = us(~stm_);
+                        auto king_sq     = kingSq(stm_);
 
                         Bitboard checkmask;
                         Bitboard pin_hv;
@@ -2228,7 +2254,7 @@ class Board {
 
     void set960(bool is960) {
         chess960_ = is960;
-        setFen(original_fen_);
+        if (!original_fen_.empty()) setFen(original_fen_);
     }
 
     /// @brief Checks if the current position is a chess960, aka. FRC/DFRC position.
@@ -2428,6 +2454,284 @@ class Board {
 
     friend std::ostream &operator<<(std::ostream &os, const Board &board);
 
+    /// @brief Compresses the board into a PackedBoard
+    class Compact {
+        friend class Board;
+        Compact() = default;
+
+       public:
+        /// @brief Compresses the board into a PackedBoard
+        static PackedBoard encode(const Board &board) { return encodeState(board); }
+
+        static PackedBoard encode(std::string_view fen, bool chess960 = false) { return encodeState(fen, chess960); }
+
+        /// @brief Creates a Board object from a PackedBoard
+        /// @param compressed
+        /// @param chess960 If the board is a chess960 position, set this to true
+        static Board decode(const PackedBoard &compressed, bool chess960 = false) {
+            Board board{};
+            board.chess960_ = chess960;
+            decode(board, compressed);
+            return board;
+        }
+
+       private:
+        /**
+         * A compact board representation can be achieved in 24 bytes,
+         * we use 8 bytes (64bit) to store the occupancy bitboard,
+         * and 16 bytes (128bit) to store the pieces (plus some special information).
+         *
+         * Each of the 16 bytes can store 2 pieces, since chess only has 12 different pieces,
+         * we can represent the pieces from 0 to 11 in 4 bits (a nibble) and use the other 4 bit for
+         * the next piece.
+         * Since we need to store information about enpassant, castling rights and the side to move,
+         * we can use the remaining 4 bits to store this information.
+         *
+         * However we need to store the information and the piece information together.
+         * This means in our case that
+         * 12 -> enpassant + a pawn, we can deduce the color of the pawn from the rank of the square
+         * 13 -> white rook with castling rights, we later use the file to deduce if it's a short or long castle
+         * 14 -> black rook with castling rights, we later use the file to deduce if it's a short or long castle
+         * 15 -> black king and black is side to move
+         *
+         * We will later deduce the square of the pieces from the occupancy bitboard.
+         */
+        static PackedBoard encodeState(const Board &board) {
+            PackedBoard packed{};
+
+            packed[0] = board.occ().getBits() >> 56;
+            packed[1] = (board.occ().getBits() >> 48) & 0xFF;
+            packed[2] = (board.occ().getBits() >> 40) & 0xFF;
+            packed[3] = (board.occ().getBits() >> 32) & 0xFF;
+            packed[4] = (board.occ().getBits() >> 24) & 0xFF;
+            packed[5] = (board.occ().getBits() >> 16) & 0xFF;
+            packed[6] = (board.occ().getBits() >> 8) & 0xFF;
+            packed[7] = board.occ().getBits() & 0xFF;
+
+            auto offset = 8 * 2;
+            auto occ    = board.occ();
+
+            while (occ) {
+                // we now fill the packed array, since our convertedpiece only actually needs 4 bits,
+                // we can store 2 pieces in one byte.
+                const auto sq      = Square(occ.pop());
+                const auto shift   = (offset % 2 == 0 ? 4 : 0);
+                const auto meaning = convertMeaning(board.cr_, board.sideToMove(), board.ep_sq_, sq, board.at(sq));
+                const auto nibble  = meaning << shift;
+
+                packed[offset / 2] |= nibble;
+                offset++;
+            }
+
+            return packed;
+        }
+
+        static PackedBoard encodeState(std::string_view fen, bool chess960 = false) {
+            // fallback to slower method
+            if (chess960) {
+                Board board = Board(fen, true);
+                return encodeState(board);
+            }
+
+            PackedBoard packed{};
+
+            while (fen[0] == ' ') fen.remove_prefix(1);
+
+            const auto params     = split_string_view<6>(fen);
+            const auto position   = params[0].has_value() ? *params[0] : "";
+            const auto move_right = params[1].has_value() ? *params[1] : "w";
+            const auto castling   = params[2].has_value() ? *params[2] : "-";
+            const auto en_passant = params[3].has_value() ? *params[3] : "-";
+
+            const auto ep  = en_passant == "-" ? Square::underlying::NO_SQ : Square(en_passant);
+            const auto stm = (move_right == "w") ? Color::WHITE : Color::BLACK;
+
+            CastlingRights cr;
+
+            for (char i : castling) {
+                if (i == '-') break;
+
+                const auto king_side  = CastlingRights::Side::KING_SIDE;
+                const auto queen_side = CastlingRights::Side::QUEEN_SIDE;
+
+                if (i == 'K') cr.setCastlingRight(Color::WHITE, king_side, File::FILE_H);
+                if (i == 'Q') cr.setCastlingRight(Color::WHITE, queen_side, File::FILE_A);
+                if (i == 'k') cr.setCastlingRight(Color::BLACK, king_side, File::FILE_H);
+                if (i == 'q') cr.setCastlingRight(Color::BLACK, queen_side, File::FILE_A);
+
+                assert(i == 'K' || i == 'Q' || i == 'k' || i == 'q');
+
+                continue;
+            }
+
+            const auto parts = split_string_view<8>(position, '/');
+
+            auto offset = 8 * 2;
+            auto square = 0;
+            auto occ    = Bitboard(0);
+
+            for (auto i = parts.rbegin(); i != parts.rend(); i++) {
+                auto part = *i;
+
+                for (char curr : *part) {
+                    if (isdigit(curr)) {
+                        square += (curr - '0');
+                    } else if (curr == '/') {
+                        square++;
+                    } else {
+                        const auto p     = Piece(std::string_view(&curr, 1));
+                        const auto shift = (offset % 2 == 0 ? 4 : 0);
+
+                        packed[offset / 2] |= convertMeaning(cr, stm, ep, Square(square), p) << shift;
+                        offset++;
+
+                        occ.set(square);
+                        ++square;
+                    }
+                }
+            }
+
+            packed[0] = occ.getBits() >> 56;
+            packed[1] = (occ.getBits() >> 48) & 0xFF;
+            packed[2] = (occ.getBits() >> 40) & 0xFF;
+            packed[3] = (occ.getBits() >> 32) & 0xFF;
+            packed[4] = (occ.getBits() >> 24) & 0xFF;
+            packed[5] = (occ.getBits() >> 16) & 0xFF;
+            packed[6] = (occ.getBits() >> 8) & 0xFF;
+            packed[7] = occ.getBits() & 0xFF;
+
+            return packed;
+        }
+
+        static void decode(Board &board, const PackedBoard &compressed) {
+            Bitboard occupied = 0ull;
+
+            for (int i = 0; i < 8; i++) {
+                occupied |= Bitboard(compressed[i]) << (56 - i * 8);
+            }
+
+            int offset           = 16;
+            int white_castle_idx = 0, black_castle_idx = 0;
+            File white_castle[2] = {File::NO_FILE, File::NO_FILE};
+            File black_castle[2] = {File::NO_FILE, File::NO_FILE};
+
+            // clear board state
+
+            board.stm_ = Color::WHITE;
+            board.occ_bb_.fill(0ULL);
+            board.pieces_bb_.fill(0ULL);
+            board.board_.fill(Piece::NONE);
+            board.cr_.clear();
+            board.original_fen_.clear();
+            board.prev_states_.clear();
+            board.hfm_   = 0;
+            board.plies_ = 0;
+
+            // place pieces back on the board
+            while (occupied) {
+                const auto sq     = Square(occupied.pop());
+                const auto nibble = compressed[offset / 2] >> (offset % 2 == 0 ? 4 : 0) & 0b1111;
+                const auto piece  = convertPiece(nibble);
+
+                if (piece != Piece::NONE) {
+                    board.placePiece(piece, sq);
+
+                    offset++;
+                    continue;
+                }
+
+                // Piece has a special meaning, interpret it from the raw integer
+                // pawn with ep square behind it
+                if (nibble == 12) {
+                    board.ep_sq_ = sq.ep_square();
+                    // depending on the rank this is a white or black pawn
+                    auto color = sq.rank() == Rank::RANK_4 ? Color::WHITE : Color::BLACK;
+                    board.placePiece(Piece(PieceType::PAWN, color), sq);
+                }
+                // castling rights for white
+                else if (nibble == 13) {
+                    assert(white_castle_idx < 2);
+                    white_castle[white_castle_idx++] = sq.file();
+                    board.placePiece(Piece(PieceType::ROOK, Color::WHITE), sq);
+                }
+                // castling rights for black
+                else if (nibble == 14) {
+                    assert(black_castle_idx < 2);
+                    black_castle[black_castle_idx++] = sq.file();
+                    board.placePiece(Piece(PieceType::ROOK, Color::BLACK), sq);
+                }
+                // black to move
+                else if (nibble == 15) {
+                    board.stm_ = Color::BLACK;
+                    board.placePiece(Piece(PieceType::KING, Color::BLACK), sq);
+                }
+
+                offset++;
+            }
+
+            // reapply castling
+            for (int i = 0; i < 2; i++) {
+                if (white_castle[i] != File::NO_FILE) {
+                    const auto king_sq = board.kingSq(Color::WHITE);
+                    const auto file    = white_castle[i];
+                    const auto side    = CastlingRights::closestSide(file, king_sq.file());
+
+                    board.cr_.setCastlingRight(Color::WHITE, side, file);
+                }
+
+                if (black_castle[i] != File::NO_FILE) {
+                    const auto king_sq = board.kingSq(Color::BLACK);
+                    const auto file    = black_castle[i];
+                    const auto side    = CastlingRights::closestSide(file, king_sq.file());
+
+                    board.cr_.setCastlingRight(Color::BLACK, side, file);
+                }
+            }
+
+            if (board.stm_ == Color::BLACK) {
+                board.plies_++;
+            }
+
+            board.key_ = board.zobrist();
+        }
+
+        // 1:1 mapping of Piece::internal() to the compressed piece
+        static std::uint8_t convertPiece(Piece piece) { return int(piece.internal()); }
+
+        // for pieces with a special meaning return Piece::NONE since this is otherwise not used
+        static Piece convertPiece(std::uint8_t piece) {
+            if (piece >= 12) return Piece::NONE;
+            return Piece(Piece::underlying(piece));
+        }
+
+        // 12 => theres an ep square behind the pawn, rank will be deduced from the rank
+        // 13 => any white rook with castling rights, side will be deduced from the file
+        // 14 => any black rook with castling rights, side will be deduced from the file
+        // 15 => black king and black is side to move
+        static std::uint8_t convertMeaning(const CastlingRights &cr, Color stm, Square ep, Square sq, Piece piece) {
+            if (piece.type() == PieceType::PAWN && ep != Square::underlying::NO_SQ) {
+                if (Square(static_cast<int>(sq.index()) ^ 8) == ep) return 12;
+            }
+
+            if (piece.type() == PieceType::ROOK) {
+                if (piece.color() == Color::WHITE && Square::back_rank(sq, Color::WHITE) &&
+                    (cr.getRookFile(Color::WHITE, CastlingRights::Side::KING_SIDE) == sq.file() ||
+                     cr.getRookFile(Color::WHITE, CastlingRights::Side::QUEEN_SIDE) == sq.file()))
+                    return 13;
+                if (piece.color() == Color::BLACK && Square::back_rank(sq, Color::BLACK) &&
+                    (cr.getRookFile(Color::BLACK, CastlingRights::Side::KING_SIDE) == sq.file() ||
+                     cr.getRookFile(Color::BLACK, CastlingRights::Side::QUEEN_SIDE) == sq.file()))
+                    return 14;
+            }
+
+            if (piece.type() == PieceType::KING && piece.color() == Color::BLACK && stm == Color::BLACK) {
+                return 15;
+            }
+
+            return convertPiece(piece);
+        }
+    };
+
    protected:
     virtual void placePiece(Piece piece, Square sq) {
         assert(board_[sq.index()] == Piece::NONE);
@@ -2489,26 +2793,7 @@ class Board {
         // find leading whitespaces and remove them
         while (fen[0] == ' ') fen.remove_prefix(1);
 
-        static auto split_fen = [](std::string_view fen) {
-            std::array<std::optional<std::string_view>, 6> arr = {};
-
-            std::size_t start = 0;
-            std::size_t end   = 0;
-
-            for (std::size_t i = 0; i < 6; i++) {
-                end = fen.find(' ', start);
-                if (end == std::string::npos) {
-                    arr[i] = fen.substr(start);
-                    break;
-                }
-                arr[i] = fen.substr(start, end - start);
-                start  = end + 1;
-            }
-
-            return arr;
-        };
-
-        const auto params     = split_fen(fen);
+        const auto params     = split_string_view<6>(fen);
         const auto position   = params[0].has_value() ? *params[0] : "";
         const auto move_right = params[1].has_value() ? *params[1] : "w";
         const auto castling   = params[2].has_value() ? *params[2] : "-";
@@ -2621,6 +2906,27 @@ class Board {
         assert(key_ == zobrist());
     }
 
+    template <int N>
+    std::array<std::optional<std::string_view>, N> static split_string_view(std::string_view fen,
+                                                                            char delimiter = ' ') {
+        std::array<std::optional<std::string_view>, N> arr = {};
+
+        std::size_t start = 0;
+        std::size_t end   = 0;
+
+        for (std::size_t i = 0; i < N; i++) {
+            end = fen.find(delimiter, start);
+            if (end == std::string::npos) {
+                arr[i] = fen.substr(start);
+                break;
+            }
+            arr[i] = fen.substr(start, end - start);
+            start  = end + 1;
+        }
+
+        return arr;
+    }
+
     // store the original fen string
     // useful when setting up a frc position and the user called set960(true) afterwards
     std::string original_fen_;
@@ -2675,6 +2981,15 @@ template <Direction direction>
         case Direction::SOUTH_EAST:
             return (b & ~MASK_FILE[7]) >> 7;
     }
+
+        // c++23
+#if defined(__cpp_lib_unreachable) && __cpp_lib_unreachable >= 202202L
+    std::unreachable();
+#endif
+
+    assert(false);
+
+    return {};
 }
 
 /// @brief [Internal Usage] Generate the left side pawn attacks.
@@ -4090,7 +4405,6 @@ class StreamParser {
 }  // namespace chess::pgn
 
 #include <sstream>
-#include <utility>
 
 
 namespace chess {

--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -160,6 +160,12 @@ public:
 
     m = uci::parseSan(board, move, moves);
 
+    // chess-lib may call move() with empty strings for move
+    if (m == Move::NO_MOVE) {
+      this->skipPgn(true);
+      return;
+    }
+
     board.makeMove<true>(m);
 
     if (tb_limit > 1) {


### PR DESCRIPTION
I did some quick tests, and this seems to work as expected. Notice that I used a cop-out for the move counters. (They are not stored in the fen_map, and so will only be printed using the lock, not at the very end with the counts.)

Maybe you would like to test the effect on memory pressure before merging this?

(I could not run this on a large collection of pgns, because the chess library seems to throw an exception on fishtest pgns. Will open a separate issue for that.)