### PR TITLE
update chess-library to 0.6.77

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Options:
   --maxPlies <N>        Maximum number of plies to consider from the game, excluding book moves (default 20)
   --stopEarly           Stop analysing the game as soon as countStopEarly new positions are reached (default false) for the analysing thread.
   --countStopEarly <N>  Number of new positions encountered before stopping with stopEarly (default 1)
-  --minCount <N>        Minimum count of the positin before being written to file (default 1)
+  --minCount <N>        Minimum count of the position before being written to file (default 1)
   --saveCount           Add to the output file the count of each position. This adds significant memory overhead (but can be faster). Requires --omitMoveCounter.
   --omitMoveCounter     Omit movecounter when storing the FEN (the same position with different movecounters is still only stored once)
   --TBlimit <N>         Omit positions with N pieces, or fewer (default: 1)


### PR DESCRIPTION
Main branch gives parsing errors on some fishtest data, e.g.:
```
> ./fastpopular -r --minCount 2 --maxPlies 60 --matchBook UHO_Lichess_4852_v1.epd --stopEarly --countStopEarly 6 --cdb -o popular_Lichess_UHO_LTC_to_202410_mincount2_plies60_stopEarly6.epd
Looking (recursively) for pgn files in ./pgns
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Found 907 .pgn(.gz) files, creating 91 chunks for processing.
Processed 338 filesError when parsing: ./pgns/24-06-30/6681afc7af9f86394d0966dd/6681afc7af9f86394d0966dd.pgn.gz
Failed to parse san. At step 3: [Event rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Processed 374 filesError when parsing: ./pgns/24-06-30/6681b3f2ea63423c790b64d3/6681b3f2ea63423c790b64d3.pgn.gz
Failed to parse san. At step 3: [Event rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Processed 585 filesError when parsing: ./pgns/24-07-07/668b1505cf91c430fca58627/668b1505cf91c430fca58627.pgn.gz
Failed to parse san. At step 3: [Event rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Processed 814 filesError when parsing: ./pgns/24-10-01/66fb690e86d5ee47d953b8eb/66fb690e86d5ee47d953b8eb.pgn.gz
Failed to parse san. At step 3: Qe[Event rnbq1rk1/p3bppp/1p2p3/2p1P3/1P1P1P1P/P1N1nN2/1BQ1B1P1/R3K2R w KQ - 1 15
Processed 907 files
Retained 272121378 positions from 632275541 unique visited in 107157457 games.
Total time for processing: 1872.28 s
```

Updating to the latest version of chess-library fixes the first three. The final one is correct, due to a corrupt pgn file.