### PR TITLE
catch more exceptions

### DIFF
--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -172,7 +172,7 @@ public:
       }
 
       board.makeMove<true>(m);
-    } catch (std::exception &e) {
+    } catch (const std::exception &e) {
       std::cerr << "While parsing " << file << " encountered: " << e.what()
                 << '\n';
       this->skipPgn(true);


### PR DESCRIPTION
This PR implements the suggestion from @Disservin.

master:
```
> ./fastpopular --file lichess_db_broadcast_2020-01.pgn --maxPlies 80
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Error when parsing: lichess_db_broadcast_2020-01.pgn
Failed to parse san. At step 3: Kd4 6k1/5p2/1R4rb/1Qp1p2p/8/2P1K1BP/1Pq5/6R1 w - - 1 35
Processed 1 files
Retained 17846 positions from 17846 unique visited in 280 games.
Total time for processing: 0.03 s
```

patch:
```
> ./fastpopular --file lichess_db_broadcast_2020-01.pgn --maxPlies 80
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Kd4 6k1/5p2/1R4rb/1Qp1p2p/8/2P1K1BP/1Pq5/6R1 w - - 1 35
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke8 8/1p1k4/p1r4p/6p1/8/2P1R3/B4PP1/6K1 b - - 2 37
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Kd5 4rbQ1/1b6/pp2kPp1/4pqB1/2rP4/5P2/P2RNKP1/7R b - - 5 30
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke5 8/2p5/4bk2/3p2p1/3P4/1B2K3/1P4P1/8 b - - 1 32
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke4 7r/3k4/2b1p1p1/p1PpPpPp/Pp1K1P1P/1P6/4B3/R7 w - - 7 37
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke4 2r5/pp3p1p/2rkb1p1/3p2P1/P2K4/3B4/1P4PP/4RR2 w - - 1 34
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke4+ 8/1p4p1/p4b1p/4kB2/PPp3P1/4K3/2P3PP/8 w - - 2 33
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke5 3r4/pp3ppp/4k3/2R5/7P/P3K1P1/1P3P2/8 b - - 8 33
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Kxe4+ 8/1p5p/6p1/p2pk3/4b3/2P1K3/PP4PP/5B2 w - - 0 31
While parsing lichess_db_broadcast_2020-01.pgn encountered: Failed to parse san. At step 3: Ke5+ 8/p1r5/R3pkp1/2P4p/4K2P/R7/P2r2P1/8 b - - 5 35
Processed 1 files
Retained 56526 positions from 56526 unique visited in 952 games.
Total time for processing: 0.092 s
```

Fixes #21.