### PR TITLE
filter out nonstandard chess variants

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,9 +21,10 @@ The analysis runs multi-threaded, typically limited by the speed of the storage.
 ```
 Usage: ./fastpopular [options]
 Options:
-  --file <path>         Path to .pgn(.gz) file
-  --dir <path>          Path to directory containing .pgn(.gz) files (default: pgns)
-  -r                    Search for .pgn(.gz) files recursively in subdirectories
+  --file <path>         Path to .pgn([.gz|.zst]) file
+  --dir <path>          Path to directory containing .pgn([.gz|.zst]) files (default: pgns)
+  -r                    Search for .pgn([.gz|.zst]) files recursively in subdirectories
+  --noFRC               Exclude (D)FRC games (included by default)
   --allowDuplicates     Allow duplicate directories for test pgns
   --concurrency <N>     Number of concurrent threads to use (default: maximum)
   --matchEngine <regex> Filter data based on engine name

--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -57,17 +57,17 @@ static constexpr int map_size = 1200000;
 /// filter if present
 class Analyze : public pgn::Visitor {
 public:
-  Analyze(std::string_view file, const std::string &regex_engine,
-          const std::string &move_counter, const unsigned int count_stop_early,
-          const int max_plies, std::ofstream &out_file, const int min_count,
-          const bool save_count, const bool omit_move_counter,
-          const unsigned int tb_limit, const bool omit_mates, const int min_Elo,
-          std::mutex &progress_output)
-      : file(file), regex_engine(regex_engine), move_counter(move_counter),
-        count_stop_early(count_stop_early), max_plies(max_plies),
-        out_file(out_file), min_count(min_count), save_count(save_count),
-        omit_move_counter(omit_move_counter), tb_limit(tb_limit),
-        omit_mates(omit_mates), min_Elo(min_Elo),
+  Analyze(std::string_view file, const bool no_frc,
+          const std::string &regex_engine, const std::string &move_counter,
+          const unsigned int count_stop_early, const int max_plies,
+          std::ofstream &out_file, const int min_count, const bool save_count,
+          const bool omit_move_counter, const unsigned int tb_limit,
+          const bool omit_mates, const int min_Elo, std::mutex &progress_output)
+      : file(file), no_frc(no_frc), regex_engine(regex_engine),
+        move_counter(move_counter), count_stop_early(count_stop_early),
+        max_plies(max_plies), out_file(out_file), min_count(min_count),
+        save_count(save_count), omit_move_counter(omit_move_counter),
+        tb_limit(tb_limit), omit_mates(omit_mates), min_Elo(min_Elo),
         progress_output(progress_output) {}
 
   virtual ~Analyze() {}
@@ -87,8 +87,22 @@ public:
       }
     }
 
-    if (key == "Variant" && value == "fischerandom") {
-      board.set960(true);
+    if (key == "Variant") {
+      std::string variant = to_lower(value);
+      if (variant == "chess960" || variant == "chess 960" ||
+          variant == "fischerandom" // cutechess
+          || variant == "fischerrandom" || variant == "fischer random" ||
+          variant == "from position" // lichess broadcast, TODO: check FEN
+      ) {
+        if (no_frc)
+          skip = true;
+        else
+          board.set960(true);
+      } else if (variant == "standard") { // TODO: check FEN
+      } else {
+        skip = true; // variants like antichess, atomic, crazyhouse, etc
+        // TODO: collect set of rejected variants, to display to user at the end
+      }
     }
 
     if (key == "Result") {
@@ -120,7 +134,7 @@ public:
   }
 
   void startMoves() override {
-    if (!hasResult) {
+    if (skip || !hasResult) {
       this->skipPgn(true);
       return;
     }
@@ -238,7 +252,7 @@ public:
     board.set960(false);
     board.setFen(constants::STARTPOS);
 
-    hasResult = false;
+    skip = hasResult = false;
 
     retained_plies = 0;
     new_entry_count = 0;
@@ -253,6 +267,7 @@ public:
 
 private:
   std::string_view file;
+  const bool no_frc;
   const std::string &regex_engine;
   const std::string &move_counter;
   const unsigned int count_stop_early;
@@ -285,7 +300,7 @@ private:
   unsigned int new_entry_count = 0;
 };
 
-void ana_files(const std::vector<std::string> &files,
+void ana_files(const std::vector<std::string> &files, bool no_frc,
                const std::string &regex_engine, const map_meta &meta_map,
                bool fix_fens, const int max_plies,
                const unsigned int count_stop_early, std::ofstream &out_file,
@@ -331,7 +346,7 @@ void ana_files(const std::vector<std::string> &files,
 
     const auto pgn_iterator = [&](std::istream &iss) {
       auto vis = std::make_unique<Analyze>(
-          file, regex_engine, move_counter, count_stop_early, max_plies,
+          file, no_frc, regex_engine, move_counter, count_stop_early, max_plies,
           out_file, min_count, save_count, omit_move_counter, tb_limit,
           omit_mates, min_Elo, progress_output);
 
@@ -463,7 +478,7 @@ void filter_files_sprt(std::vector<std::string> &file_list,
                   file_list.end());
 }
 
-void process(const std::vector<std::string> &files_pgn,
+void process(const std::vector<std::string> &files_pgn, bool no_frc,
              const std::string &regex_engine, const map_meta &meta_map,
              bool fix_fens, const int max_plies,
              const unsigned int count_stop_early, std::ofstream &out_file,
@@ -487,14 +502,14 @@ void process(const std::vector<std::string> &files_pgn,
 
   for (const auto &files : files_chunked) {
 
-    pool.enqueue([&files, &regex_engine, &meta_map, &fix_fens, &progress_output,
-                  &files_chunked, &max_plies, &count_stop_early, &out_file,
-                  &min_count, &save_count, omit_move_counter, &tb_limit,
-                  &omit_mates, &min_Elo]() {
-      analysis::ana_files(files, regex_engine, meta_map, fix_fens, max_plies,
-                          count_stop_early, out_file, min_count, save_count,
-                          omit_move_counter, tb_limit, omit_mates, min_Elo,
-                          progress_output);
+    pool.enqueue([&files, no_frc, &regex_engine, &meta_map, &fix_fens,
+                  &progress_output, &files_chunked, &max_plies,
+                  &count_stop_early, &out_file, &min_count, &save_count,
+                  omit_move_counter, &tb_limit, &omit_mates, &min_Elo]() {
+      analysis::ana_files(files, no_frc, regex_engine, meta_map, fix_fens,
+                          max_plies, count_stop_early, out_file, min_count,
+                          save_count, omit_move_counter, tb_limit, omit_mates,
+                          min_Elo, progress_output);
     });
   }
 
@@ -511,6 +526,7 @@ void print_usage(char const *program_name) {
     ss << "  --file <path>         Path to .pgn([.gz|.zst]) file" << "\n";
     ss << "  --dir <path>          Path to directory containing .pgn([.gz|.zst]) files (default: pgns)" << "\n";
     ss << "  -r                    Search for .pgn([.gz|.zst]) files recursively in subdirectories" << "\n";
+    ss << "  --noFRC               Exclude (D)FRC games (included by default)" << "\n";
     ss << "  --allowDuplicates     Allow duplicate directories for test pgns" << "\n";
     ss << "  --concurrency <N>     Number of concurrent threads to use (default: maximum)" << "\n";
     ss << "  --matchEngine <regex> Filter data based on engine name" << "\n";
@@ -521,7 +537,7 @@ void print_usage(char const *program_name) {
     ss << "  --maxPlies <N>        Maximum number of plies to consider from the game, excluding book moves (default 20)" << "\n";
     ss << "  --stopEarly           Stop analysing the game as soon as countStopEarly new positions are reached (default false) for the analysing thread." << "\n";
     ss << "  --countStopEarly <N>  Number of new positions encountered before stopping with stopEarly (default 1)" << "\n";
-    ss << "  --minCount <N>        Minimum count of the positin before being written to file (default 1)" << "\n";
+    ss << "  --minCount <N>        Minimum count of the position before being written to file (default 1)" << "\n";
     ss << "  --saveCount           Add to the output file the count of each position. This adds significant memory overhead (but can be faster). Requires --omitMoveCounter." << "\n";
     ss << "  --omitMoveCounter     Omit movecounter when storing the FEN (the same position with different movecounters is still only stored once)" << "\n";
     ss << "  --TBlimit <N>         Omit positions with N pieces, or fewer (default: 1)" << "\n";
@@ -592,6 +608,7 @@ int main(int argc, char const *argv[]) {
     }
   }
 
+  bool no_frc = find_argument(args, pos, "--noFRC", true);
   bool omit_move_counter = find_argument(args, pos, "--omitMoveCounter", true);
   bool allow_duplicates = find_argument(args, pos, "--allowDuplicates", true);
   unsigned int tb_limit = 1;
@@ -664,7 +681,7 @@ int main(int argc, char const *argv[]) {
 
   const auto t0 = std::chrono::high_resolution_clock::now();
 
-  process(files_pgn, regex_engine, meta_map, fix_fens, max_plies,
+  process(files_pgn, no_frc, regex_engine, meta_map, fix_fens, max_plies,
           count_stop_early, out_file, min_count, save_count, omit_move_counter,
           tb_limit, omit_mates, min_Elo, concurrency);
 

--- a/fastpopular.hpp
+++ b/fastpopular.hpp
@@ -153,3 +153,10 @@ inline bool find_argument(const std::vector<std::string> &args,
   return pos != args.end() &&
          (without_parameter || std::next(pos) != args.end());
 }
+
+inline std::string to_lower(std::string_view s) {
+  std::string result(s);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return result;
+}


### PR DESCRIPTION
This PR allows to skip games from non-standard variants, which is helpful when parsing the Lichess broadcast games mentioned in #21.

While at it, we also introduce the flag `--noFRC` to also skip any (D)FRC games that are signposted as such in the `Variant` header of the PGN.

I did a quick check of popular game collections regarding the possible `Variant` header flag in the PGN files: The Hugging Face repo of Fishtest games only contains a few games with `"fischerandom"` from the cutechess days. The Lichess broadcast DBs contain e.g. `"Standard"`,  `"From Position"`, `"Crazyhouse"`, `"Fischerandom"`, `"Chess960"`. For the additional possible values for (D)FRC games I followed the convention of python-chess.

Main:
```
> ./fastpopular --file lichess_db_broadcast_2020-12.pgn 
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Error when parsing: lichess_db_broadcast_2020-12.pgn
Failed to parse san. At step 3: N@e4 rnbqr1k1/ppp2ppp/5p2/3p4/3P1N2/2P5/P1P1BPPP/R1BQK2R b KQ - 0 9
Processed 1 files
Retained 9898 positions from 9898 unique visited in 966 games.
Total time for processing: 0.046 s

> ./fastpopular --file lichess_db_antichess_rated_2025-04.pgn
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Error when parsing: lichess_db_antichess_rated_2025-04.pgn
Failed to parse san. At step 3: Rxc2 1nbqkbnr/2Nppp1p/2r3p1/p7/P7/6P1/2PPPP1P/R1BQKBNR b KQk - 0 7
Processed 1 files
Retained 33 positions from 33 unique visited in 2 games.
Total time for processing: 0.005 s
```

Patch:
```
> ./fastpopular --file lichess_db_broadcast_2020-12.pgn 
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Processed 1 files
Retained 16439 positions from 16439 unique visited in 1730 games.
Total time for processing: 0.048 s

> ./fastpopular --file lichess_db_broadcast_2020-12.pgn --noFRC
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Processed 1 files
Retained 15705 positions from 15705 unique visited in 1620 games.
Total time for processing: 0.049 s

> ./fastpopular --file lichess_db_antichess_rated_2025-04.pgn
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 0 games.
Total time for processing: 1.817 s
```

