### PR TITLE
check for chess960 castling rights

### DIFF
--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -318,7 +318,7 @@ private:
   Board board;
   Movelist moves;
 
-  std::string fen;
+  std::string fen = constants::STARTPOS;
   bool is960 = false;
   bool skip = false;
   bool hasResult = false;


### PR DESCRIPTION
This PR checks if the `FEN` tag in the PGN contains castling rights that cannot be for classical chess.

Since the order of the `Variant` and `FEN` tags are not prescribed, the logic in master had to be adapted a bit.

A second pair of eyes by @Disservin would be good. (If the `has_chess960_castling_rights()` function might be useful for other users of chess-lib as well, you are free to add it there in some shape or form.)