### PR TITLE
improve chess960 detection

### DIFF
--- a/fastpopular.hpp
+++ b/fastpopular.hpp
@@ -160,3 +160,24 @@ inline std::string to_lower(std::string_view s) {
                  [](unsigned char c) { return std::tolower(c); });
   return result;
 }
+
+template <int N>
+std::array<std::optional<std::string_view>, N> static split_string_view(
+    std::string_view fen, char delimiter = ' ') {
+  std::array<std::optional<std::string_view>, N> arr = {};
+
+  std::size_t start = 0;
+  std::size_t end = 0;
+
+  for (std::size_t i = 0; i < N; i++) {
+    end = fen.find(delimiter, start);
+    if (end == std::string::npos) {
+      arr[i] = fen.substr(start);
+      break;
+    }
+    arr[i] = fen.substr(start, end - start);
+    start = end + 1;
+  }
+
+  return arr;
+}


### PR DESCRIPTION
It turns out that `board.setFen(fen)` fails if `fen` contains DFRC castling rights and `chess960` is not set. This PR fixes this by first checking for DFRC castling rights in the FEN. 

In addition, if `board.setFen()` fails we no longer exit, but simply skip that game.

Finally, in `has_chess960_castling_rights()` we now also catch the 17 FRC starting positions that are not standard chess.

main:
```
> ./fastpopular --file DFRC_openings.pgn
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Error: Failed to parse FEN rqnnkbbr/pppppppp/8/8/8/8/PPPPPPPP/RQNNKBBR w HAha - 0 1

> ./fastpopular --file DFRC_openings.pgn --noFRC
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Error: Failed to parse FEN rqnnkbbr/pppppppp/8/8/8/8/PPPPPPPP/RQNNKBBR w HAha - 0 1 

> ./fastpopular --file FRC_openings.pgn
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 960 games.
Total time for processing: 0.005 s

> ./fastpopular --file FRC_openings.pgn --noFRC
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 18 games.
Total time for processing: 0.012 s
```

patch:
```
> ./fastpopular --file DFRC_openings.pgn
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 921600 games.
Total time for processing: 1.487 s

> ./fastpopular --file DFRC_openings.pgn --noFRC
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 0 games.
Total time for processing: 0.285 s

> ./fastpopular --file FRC_openings.pgn 
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 960 games.
Total time for processing: 0.008 s

> ./fastpopular --file FRC_openings.pgn --noFRC
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 0 positions from 0 unique visited in 1 games.
Total time for processing: 0.004 s
```

PS: The function `split_string_view()` is taken verbatim from `Chess::Board`, but as it is private there we cannot use it directly.