### PR TITLE
small simplification

### DIFF
--- a/fastpopular.cpp
+++ b/fastpopular.cpp
@@ -59,8 +59,8 @@ std::atomic<std::size_t> total_pos = 0;
 bool has_chess960_castling_rights(std::string_view fen, bool &skip) {
 
   // check for DFRC castling rights
-  const auto params = split_string_view<3>(fen);
-  const auto castling = params[2].has_value() ? *params[2] : "-";
+  const auto parts = utils::splitString(fen, ' ');
+  const auto castling = parts.size() > 2 ? parts[2] : "-";
   for (char c : castling) {
     if (c != '-' && std::tolower(c) != 'k' && std::tolower(c) != 'q') {
       return true;
@@ -105,8 +105,10 @@ bool has_chess960_castling_rights(std::string_view fen, bool &skip) {
   if (count_castling == 4) {
     if (board.pieces(PieceType::PAWN) !=
             (Bitboard(Rank::RANK_2) | Bitboard(Rank::RANK_7)) ||
-        (board.us(Color::WHITE) & Bitboard(Rank::RANK_1)).count() != 8 ||
-        (board.us(Color::BLACK) & Bitboard(Rank::RANK_8)).count() != 8) {
+        board.us(Color::WHITE) !=
+            (Bitboard(Rank::RANK_1) | Bitboard(Rank::RANK_2)) ||
+        board.us(Color::BLACK) !=
+            (Bitboard(Rank::RANK_7) | Bitboard(Rank::RANK_8))) {
       return false;
     }
 

--- a/fastpopular.hpp
+++ b/fastpopular.hpp
@@ -160,24 +160,3 @@ inline std::string to_lower(std::string_view s) {
                  [](unsigned char c) { return std::tolower(c); });
   return result;
 }
-
-template <int N>
-std::array<std::optional<std::string_view>, N> static split_string_view(
-    std::string_view fen, char delimiter = ' ') {
-  std::array<std::optional<std::string_view>, N> arr = {};
-
-  std::size_t start = 0;
-  std::size_t end = 0;
-
-  for (std::size_t i = 0; i < N; i++) {
-    end = fen.find(delimiter, start);
-    if (end == std::string::npos) {
-      arr[i] = fen.substr(start);
-      break;
-    }
-    arr[i] = fen.substr(start, end - start);
-    start = end + 1;
-  }
-
-  return arr;
-}


### PR DESCRIPTION
We can use the function `utils::splitString` provided by chess-lib, and we can also avoid two calls to `.count()`.

No functional change.