### PR TITLE
introduce --cdfCutoff

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,12 +5,13 @@ Given a set of .pgn files (or .pgn.gz), quickly find the most commonly played po
 Example usage:
 
 ```
-$ ./fastpopular --dir download35 --minCount 8 --stopEarly --countStopEarly 6 --maxPlies 60 
-Looking for pgn files in download35
-Found 370353 .pgn(.gz) files, creating 128 chunks for processing.
-Processed 370353 files
-Retained 16619788 positions from 199330734 unique visited in 496063288 games.
-Total time for processing: 64.788 s
+$ ./fastpopular --dir pgns -r --minCount 8 --stopEarly --countStopEarly 6 --maxPlies 60
+Looking (recursively) for pgn files in pgns
+Found 830 .pgn([.gz|.zst]) files, creating 93 chunks for processing.
+Processed 830 files
+Retained 54671041 positions from 554007242 unique visited in 1981339655 visits in 92445853 games.
+Positions written to popular.epd.
+Total time for processing: 728.859 s
 ```
 
 This analyzes all games in the given directory (and all its subdirectories), analyzing games at most 60 plies deep out of the book,
@@ -39,6 +40,7 @@ Options:
   -o <path>             Path to output epd file (default: popular.epd)
   --omitMoveCounter     Omit movecounter when storing the FEN (the same position with different movecounters is in any case only stored once)
   --saveCount           Output the count of each stored position without movecounter in the file popular_sorted.epd.
+  --cdfCutoff <P>       Output the counts only of the P% most popular positions, weighted by their counts. (default: 100.0)
   --TBlimit <N>         Omit positions with N pieces, or fewer (default: 1)
   --omitMates           Omit positions without a legal move (check/stale mates)
   --minElo <N>          Omit games where WhiteElo or BlackElo < minElo (default: 0)


### PR DESCRIPTION
When `--saveCount` is chosen, the new option can limit the output of the visit counts to only the P% most popular positions. Here popularity is weighted by the number of times a positions was seen. This may be used in future to e.g. investigate cdb coverage of the top 99% positions in lichess games to a certain depth.

Sample usages:
```
> ./fastpopular --file lichess_db_standard_rated_2014-12.pgn.zst --maxPlies 16 --saveCount --cdfCutoff 90
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 6803522 positions from 6803522 unique visited in 20834606 visits in 1350176 games.
Positions written to popular.epd.
Total time for processing: 23.457 s
Obtaining counts, sorting and storing with cdfCutoff=90 ... done.
Saved the counts accounting for 90% of the total visits to popular_sorted.epd.
> wc -l popular_sorted.epd
4720061 popular_sorted.epd
```

```
> ./fastpopular --file lichess_db_standard_rated_2014-12.pgn.zst --maxPlies 16 --minCount 10 --saveCount 
Found 1 .pgn([.gz|.zst]) files, creating 1 chunks for processing.
Processed 1 files
Retained 136929 positions from 6803522 unique visited in 20834606 visits in 1350176 games.
Positions written to popular.epd.
Total time for processing: 17.413 s
Obtaining counts, sorting and storing with cdfCutoff=100 ... done.
Saved the counts accounting for 57.7039% of the total visits to popular_sorted.epd.
> wc -l popular_sorted.epd                   
136929 popular_sorted.epd
```
The second example shows that if `--minCount` is >1, then it will not be possible to reach 100% coverage of course (because some visited positions are missing in the output file).